### PR TITLE
Fixed ccm_team offset, added color to team names

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -32,9 +32,9 @@ void OnGUI(PEXCEPTION_POINTERS ExceptionInfo) {
 		if (WorldToScreen(matrix, entityList[i].position, out, screenCenterX, screenCenterY)) {
 
 			float dist = GetDistance(cameraPosition, entityList[i].position);
-			auto color = "white";
+			//auto color = "white";
 
-			sprintf(buf, "<color=%s>%s - %.2f</color>", color, TeamName[entityList[i].team], dist);
+			sprintf(buf, "<color=%s>%s - %.2f</color>", TeamColor[entityList[i].team], TeamName[entityList[i].team], dist);
 			il2cpp::draw_text(Rect{ out.X, out.Y, 100.0f, 100.0f }, buf);
 		}
 	}

--- a/memory.h
+++ b/memory.h
@@ -17,3 +17,4 @@ pointer camera;
 std::vector<Entity> entityList;
 std::vector<Entity> locationList;
 char TeamName[18][50] = { "SCP-173", "Class-D Personnel", "Spectator", "SCP-106", "Nine-Tailed Fox Scientist", "SCP-049", "Scientist", "SCP-079", "Chaos Insurgency", "SCP-096", "SCP-049-2", "Nine-Tailed Fox Lieutenant", "Nine-Tailed Fox Commander", "Nine-Tailed Fox Cadet", "TUTORIAL", "Facility Guard", "SCP-939-53", "SCP-939-89", };
+char TeamColor[18][50] = { "#ff1900", "#ffece6", "white", "#cc0000", "#4d4dff", "red", "yellow", "#ff3333", "#33cc33", "red", "#ff6666", "#3333ff", "#1a1aff", "6666ff", "white", "lightblue", "#ff3364", "#ff3364", };

--- a/offsets.h
+++ b/offsets.h
@@ -21,7 +21,7 @@ namespace offset {
 	// PlayerStats
 	constexpr pointer PlayerStats_Update = 0x15D5900;
 	constexpr pointer PlayerStats_ccm = 0x70;
-	constexpr pointer ccm_team = 0x178;
+	constexpr pointer ccm_team = 0x158;
 
 	// render
 	constexpr pointer GUI = 0x3A3330;


### PR DESCRIPTION
Fixed ccm_team offset: changed value from 0x178 to 0x158
Added colors to team names
- Added TeamColor index in memory.h containing colors.
- Replaced 'color' in sprintf in 'drawing players' to 'TeamColor[entityList[i].team]'
